### PR TITLE
appointment time -> hh:mm

### DIFF
--- a/src/AppointmentPicker/AppointmentPicker.tsx
+++ b/src/AppointmentPicker/AppointmentPicker.tsx
@@ -391,7 +391,7 @@ const AppointmentPicker = ({
       }
       const time = new Date(
         actualDay.getTime() + unitTime * key
-      ).toLocaleTimeString(local);
+      ).toLocaleTimeString(local, {hour: '2-digit', minute: '2-digit'});
       const isSelected =
         isDaySelected &&
         includeAppointment(selectedAppointments, dayNumber, appointment.number);


### PR DESCRIPTION
Hi! 
As it is never useful to have time with milliseconds I propose to set the format. 
Alternative approach would be to make an option for this, but I believe it is not that necessary. 
Maybe you will accept this change or propose other solution of setting time format without milliseconds? 

Kind regards,
Lado